### PR TITLE
fix: Always import goodle uuid, it's used to detect create/update reg…

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -243,13 +243,10 @@ func getGormFieldTag(field *ModelField) string {
 	if options != nil {
 		tag += getForeignKeyTag(field)
 		tag += getReferencesTag(field)
-		if options.GetHasMany() != nil {
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/google/uuid"})
-		} else if options.GetManyToMany() != nil {
+		if options.GetManyToMany() != nil {
 			tag += getM2MTag(field)
 			tag += getJoinForeignKeyTag(field)
 			tag += getJoinReferencesTag(field)
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/google/uuid"})
 		}
 		if options.OnUpdate != "" || options.OnDelete != "" {
 			var onUpdate, onDelete string

--- a/plugin/prepared_message.go
+++ b/plugin/prepared_message.go
@@ -30,6 +30,7 @@ func (pm *PreparedMessage) Parse() (err error) {
 	pm.Engine = *engine
 	g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "context"})
 	g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "gorm.io/gorm"})
+	g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/google/uuid"})
 	if *engine == cockroachdbEngine {
 		g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/cockroachdb/cockroach-go/v2/crdb/crdbgorm"})
 	}


### PR DESCRIPTION
…ardless of what's on the message. This fixes a bug where the import is missing if there are no hasMany or manyToMany relationships, which causes the generated protos to not compile.