### PR TITLE
fix: Fixes a bug that incorrectly identified relationships that need t…

### DIFF
--- a/plugin/model_field.go
+++ b/plugin/model_field.go
@@ -114,5 +114,5 @@ func ignoreField(field *ModelField) bool {
 }
 
 func hasReplaceRelationships(field *ModelField) bool {
-	return field.Options != nil && (field.Options.GetHasOne() != nil || field.Options.GetHasMany() != nil && field.Options.GetManyToMany() != nil)
+	return field.Options != nil && (field.Options.GetHasOne() != nil || field.Options.GetHasMany() != nil || field.Options.GetManyToMany() != nil)
 }


### PR DESCRIPTION
…o be replaced due to using && instead of ||. This causes the upsert function to not replace relationships, which results in unexpected upsert behavior.