### PR TITLE
fix: Refactor preloads to support arguments.

### DIFF
--- a/example/cockroachdb/example.pb.gorm.go
+++ b/example/cockroachdb/example.pb.gorm.go
@@ -1573,7 +1573,7 @@ func Delete[M Models](ctx context.Context, db *gorm.DB, ids []string) ([]M, erro
 }
 
 // List lists the given model type
-func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads []string) ([]M, error) {
+func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set limit
 	if limit > 0 {
@@ -1584,8 +1584,8 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 		session = session.Offset(offset)
 	}
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	// set order by
 	if orderBy != "" {
@@ -1598,11 +1598,11 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 }
 
 // GetByIds gets the given model type by id
-func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads []string) ([]M, error) {
+func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	models := []M{}
 	err := session.Where("id in ?", ids).Find(&models).Error

--- a/example/postgres/example.pb.gorm.go
+++ b/example/postgres/example.pb.gorm.go
@@ -1573,7 +1573,7 @@ func Delete[M Models](ctx context.Context, db *gorm.DB, ids []string) ([]M, erro
 }
 
 // List lists the given model type
-func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads []string) ([]M, error) {
+func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set limit
 	if limit > 0 {
@@ -1584,8 +1584,8 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 		session = session.Offset(offset)
 	}
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	// set order by
 	if orderBy != "" {
@@ -1598,11 +1598,11 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 }
 
 // GetByIds gets the given model type by id
-func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads []string) ([]M, error) {
+func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	models := []M{}
 	err := session.Where("id in ?", ids).Find(&models).Error

--- a/plugin/generics_template.go
+++ b/plugin/generics_template.go
@@ -146,7 +146,7 @@ func Delete[M Models](ctx context.Context, db *gorm.DB, ids []string) ([]M, erro
 }
 
 // List lists the given model type
-func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads []string) ([]M, error) {
+func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set limit
 	if limit > 0 {
@@ -157,8 +157,8 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 		session = session.Offset(offset)
 	}
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	// set order by
 	if orderBy != "" {
@@ -171,11 +171,11 @@ func List[M Models](ctx context.Context, db *gorm.DB, limit, offset int, orderBy
 }
 
 // GetByIds gets the given model type by id
-func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads []string) ([]M, error) {
+func GetByIds[M Models](ctx context.Context, db *gorm.DB, ids []string, preloads map[string][]interface{}) ([]M, error) {
 	session := db.Session(&gorm.Session{}).WithContext(ctx)
 	// set preloads
-	for _, preload := range preloads {
-		session = session.Preload(preload)
+	for preload, args := range preloads {
+		session = session.Preload(preload, args...)
 	}
 	models := []M{}
 	err := session.Where("id in ?", ids).Find(&models).Error

--- a/test/cockroachdb_plugin_test.go
+++ b/test/cockroachdb_plugin_test.go
@@ -242,7 +242,7 @@ func (s *CockroachdbPluginSuite) TestPreloadBelongsTo() {
 	_, err = Upsert[*User, *UserGormModel](context.Background(), cockroachdbDb, []*User{user})
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Company"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Company": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -264,7 +264,7 @@ func (s *CockroachdbPluginSuite) TestPreloadHasOne() {
 	_, err = Upsert[*Address, *AddressGormModel](context.Background(), cockroachdbDb, []*Address{address})
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Address"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Address": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -289,7 +289,7 @@ func (s *CockroachdbPluginSuite) TestPreloadHasMany() {
 	_, err = Upsert[*Comment, *CommentGormModel](context.Background(), cockroachdbDb, comments)
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Comments"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Comments": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -319,7 +319,7 @@ func (s *CockroachdbPluginSuite) TestPreloadManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), cockroachdbDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -348,7 +348,7 @@ func (s *CockroachdbPluginSuite) TestDissociateManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), cockroachdbDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -368,7 +368,7 @@ func (s *CockroachdbPluginSuite) TestDissociateManyToMany() {
 	err = DissociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), cockroachdbDb, dissociations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsersAfterDissociate, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsersAfterDissociate, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	fetchedUserAfterDissociate := fetchedUsersAfterDissociate[0]
 	// assert no longer associated
@@ -396,7 +396,7 @@ func (s *CockroachdbPluginSuite) TestReplaceManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), cockroachdbDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -417,7 +417,7 @@ func (s *CockroachdbPluginSuite) TestReplaceManyToMany() {
 	err = ReplaceManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), cockroachdbDb, replacementAssociations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err = GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err = GetByIds[*UserGormModel](context.Background(), cockroachdbDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel = fetchedUsers[0]

--- a/test/postgres_plugin_test.go
+++ b/test/postgres_plugin_test.go
@@ -213,7 +213,7 @@ func (s *PostgresPluginSuite) TestPreloadBelongsTo() {
 	_, err = Upsert[*User, *UserGormModel](context.Background(), postgresDb, []*User{user})
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Company"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Company": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -235,7 +235,7 @@ func (s *PostgresPluginSuite) TestPreloadHasOne() {
 	_, err = Upsert[*Address, *AddressGormModel](context.Background(), postgresDb, []*Address{address})
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Address"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Address": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -260,7 +260,7 @@ func (s *PostgresPluginSuite) TestPreloadHasMany() {
 	_, err = Upsert[*Comment, *CommentGormModel](context.Background(), postgresDb, comments)
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Comments"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Comments": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -290,7 +290,7 @@ func (s *PostgresPluginSuite) TestPreloadManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), postgresDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -319,7 +319,7 @@ func (s *PostgresPluginSuite) TestDissociateManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), postgresDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -339,7 +339,7 @@ func (s *PostgresPluginSuite) TestDissociateManyToMany() {
 	err = DissociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), postgresDb, dissociations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsersAfterDissociate, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsersAfterDissociate, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	fetchedUserAfterDissociate := fetchedUsersAfterDissociate[0]
 	// assert no longer associated
@@ -367,7 +367,7 @@ func (s *PostgresPluginSuite) TestReplaceManyToMany() {
 	err = AssociateManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), postgresDb, associations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err := GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel := fetchedUsers[0]
@@ -388,7 +388,7 @@ func (s *PostgresPluginSuite) TestReplaceManyToMany() {
 	err = ReplaceManyToMany[*UserGormModel, *ProfileGormModel](context.Background(), postgresDb, replacementAssociations, "Profiles")
 	require.NoError(s.T(), err)
 	// get with preload
-	fetchedUsers, err = GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, []string{"Profiles"})
+	fetchedUsers, err = GetByIds[*UserGormModel](context.Background(), postgresDb, []string{*user.Id}, map[string][]interface{}{"Profiles": nil})
 	require.NoError(s.T(), err)
 	// assert
 	expectedUserModel = fetchedUsers[0]


### PR DESCRIPTION
Refactor preloads from []string to map[string][]interface{} to support preloads with arguments.